### PR TITLE
Improves support for Ecto.Enum types

### DIFF
--- a/lib/ecto/erd/dot.ex
+++ b/lib/ecto/erd/dot.ex
@@ -142,6 +142,12 @@ defmodule Ecto.ERD.Dot do
     "#Enum<#{inspect(values)}>"
   end
 
+  defp format_field(%Field{type: {:parameterized, Ecto.Enum, %{mappings: mappings}}}, :type) do
+    keys = mappings |> Enum.into(%{}) |> Map.keys()
+
+    "#Enum<#{inspect(keys)}>"
+  end
+
   defp format_field(
          %Field{
            type:

--- a/lib/ecto/erd/dot.ex
+++ b/lib/ecto/erd/dot.ex
@@ -138,14 +138,8 @@ defmodule Ecto.ERD.Dot do
 
   defp format_field(%Field{name: name}, :name), do: inspect(name)
 
-  defp format_field(%Field{type: {:parameterized, Ecto.Enum, %{values: values}}}, :type) do
-    "#Enum<#{inspect(values)}>"
-  end
-
-  defp format_field(%Field{type: {:parameterized, Ecto.Enum, %{mappings: mappings}}}, :type) do
-    keys = mappings |> Enum.into(%{}) |> Map.keys()
-
-    "#Enum<#{inspect(keys)}>"
+  defp format_field(%Field{type: {:parameterized, Ecto.Enum, %{on_dump: on_dump}}}, :type) do
+    "#Enum<#{inspect(Map.keys(on_dump))}>"
   end
 
   defp format_field(


### PR DESCRIPTION
Adds a function clause to match the new internal representation in Ecto.Enum.

For example, we can now handle this:

```elixir
{:parameterized, Ecto.Enum,
  %{
    mappings: [foo: "foo", bar: "bar"],
    on_cast: %{"foo" => :foo, "bar" => :bar},
    on_dump: %{foo: "foo", bar: "bar"},
    on_load: %{"foo" => :foo, "bar" => :bar},
    type: :string
  }
}
```

Will be represented as `#Enum<[:foo, :bar]>`

Fixes https://github.com/fuelen/ecto_erd/issues/14