### PR TITLE
Fix embedded schemas with Ecto 3.12

### DIFF
--- a/lib/ecto/erd/document/dot.ex
+++ b/lib/ecto/erd/document/dot.ex
@@ -149,8 +149,8 @@ defmodule Ecto.ERD.Document.Dot do
   end
 
   defp format_type(
-         {:parameterized, Ecto.Embedded,
-          %Ecto.Embedded{cardinality: cardinality, related: related}}
+         {:parameterized,
+          {Ecto.Embedded, %Ecto.Embedded{cardinality: cardinality, related: related}}}
        ) do
     "#Ecto.Embedded<#{inspect([{cardinality, related}])}>"
   end


### PR DESCRIPTION
This is the same issue as #57 with the same [cause](https://github.com/elixir-ecto/ecto/commit/21c6068c9c829df13f4cb577cbd53263b4950262), but it also affects `Ecto.Embedded`, not just `Ecto.Enum` which was fixed in #57 