### PR TITLE
Update `Mermaid.format_type/1` to Be Compatible with Ecto v3.12 Parameterized Types

### DIFF
--- a/lib/ecto/erd/document/mermaid.ex
+++ b/lib/ecto/erd/document/mermaid.ex
@@ -120,7 +120,7 @@ defmodule Ecto.ERD.Document.Mermaid do
       :naive_datetime -> "timestamp"
       :naive_datetime_usec -> "timestamp"
       atom when is_atom(atom) -> Atom.to_string(atom)
-      {:parameterized, _, _} -> "unknown"
+      {:parameterized, _} -> "unknown"
     end
   end
 


### PR DESCRIPTION
## Summary

Hello 👋🏻 

Thanks for maintaining this library! 🎉 

After upgrading to Ecto 3.12 and generating docs with this library, I noticed that this bit of code used to format types during rendering is expecting the pre-3.12 structure for parameterized types and was raising a `CaseClauseError` exception for one of our Clickhouse types: `{:parameterized, {Ch, {:map, :string, :string}}`.

This one-line pr just updates the case clause to match the two-element tuple structure of parameterized types, similar to other prs in this repo #58 & #57 .

Let me know if you have any questions, or feedback 🙂 