### PR TITLE
  Add primary key indicator to DOT format output

### DIFF
--- a/lib/ecto/erd/document/dot.ex
+++ b/lib/ecto/erd/document/dot.ex
@@ -98,7 +98,7 @@ defmodule Ecto.ERD.Document.Dot do
 
                 case column do
                   :type -> {:i, [], {:font, [color: :gray54], text}}
-                  :name -> text
+                  :name -> if field.primary?, do: {:b, [], text}, else: text
                 end
             end)}}
         end)
@@ -139,10 +139,7 @@ defmodule Ecto.ERD.Document.Dot do
     Render.in_quotes(Node.id(source, schema_module)) <> " [label= <#{table}>]"
   end
 
-  defp format_field(%Field{name: name, primary?: primary?}, :name) do
-    field_name = inspect(name)
-    if primary?, do: field_name <> " [PK]", else: field_name
-  end
+  defp format_field(%Field{name: name}, :name), do: inspect(name)
 
   defp format_field(%Field{type: type}, :type), do: format_type(type)
 

--- a/lib/ecto/erd/document/dot.ex
+++ b/lib/ecto/erd/document/dot.ex
@@ -139,7 +139,11 @@ defmodule Ecto.ERD.Document.Dot do
     Render.in_quotes(Node.id(source, schema_module)) <> " [label= <#{table}>]"
   end
 
-  defp format_field(%Field{name: name}, :name), do: inspect(name)
+  defp format_field(%Field{name: name, primary?: primary?}, :name) do
+    field_name = inspect(name)
+    if primary?, do: field_name <> " [PK]", else: field_name
+  end
+
   defp format_field(%Field{type: type}, :type), do: format_type(type)
 
   defp format_type({:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}) do

--- a/test/ecto/erd_test.exs
+++ b/test/ecto/erd_test.exs
@@ -11,7 +11,9 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :flow,
-              type: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:simple, :complex])}
+              type:
+                {:parameterized,
+                 {Ecto.Enum, %{on_dump: %{simple: "simple", complex: "complex"}}}}
             })
           ]
         },
@@ -20,7 +22,9 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :flow,
-              type: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:simple, :complex])}
+              type:
+                {:parameterized,
+                 {Ecto.Enum, %{on_dump: %{simple: "simple", complex: "complex"}}}}
             })
           ]
         },
@@ -30,8 +34,9 @@ defmodule Ecto.ERDTest do
             Field.new(%{
               name: :status,
               type:
-                {:parameterized, Ecto.Enum,
-                 Ecto.Enum.init(values: [:active, :suspended, :invited])}
+                {:parameterized,
+                 {Ecto.Enum,
+                  %{on_dump: %{active: "active", suspended: "suspended", invited: "invited"}}}}
             })
           ]
         },
@@ -40,7 +45,9 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :status,
-              type: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:active, :suspended])}
+              type:
+                {:parameterized,
+                 {Ecto.Enum, %{on_dump: %{active: "active", suspended: "suspended"}}}}
             })
           ]
         },
@@ -49,7 +56,8 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :status,
-              type: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:live, :closed])}
+              type:
+                {:parameterized, {Ecto.Enum, %{on_dump: %{live: "live", closed: "closed"}}}}
             })
           ]
         }

--- a/test/ecto/erd_test.exs
+++ b/test/ecto/erd_test.exs
@@ -1,7 +1,7 @@
 defmodule Ecto.ERDTest do
   use ExUnit.Case
-  alias Ecto.ERD.{Node, Field}
-  alias Ecto.ERD.Document.DBML
+  alias Ecto.ERD.{Node, Field, Graph}
+  alias Ecto.ERD.Document.{DBML, Dot}
 
   test inspect(&DBML.enums_mapping/1) do
     result =
@@ -63,5 +63,30 @@ defmodule Ecto.ERDTest do
              ["projects", :status] => {"projects_status", ["closed", "live"]},
              ["users", :status] => {"users_status", ["active", "invited", "suspended"]}
            }
+  end
+
+  test "DOT format renders primary key indicator" do
+    graph = %Graph{
+      nodes: [
+        %Node{
+          source: "users",
+          schema_module: MyApp.User,
+          fields: [
+            Field.new(%{name: :id, type: :integer, primary?: true}),
+            Field.new(%{name: :email, type: :string, primary?: false}),
+            Field.new(%{name: :name, type: :string, primary?: false})
+          ]
+        }
+      ],
+      edges: []
+    }
+
+    result = Dot.render(graph, [])
+
+    # Verify that the primary key field has [PK] suffix
+    assert result =~ ~r/:id \[PK\]/
+    # Verify that non-primary fields do not have [PK] suffix
+    refute result =~ ~r/:email \[PK\]/
+    refute result =~ ~r/:name \[PK\]/
   end
 end

--- a/test/ecto/erd_test.exs
+++ b/test/ecto/erd_test.exs
@@ -83,10 +83,10 @@ defmodule Ecto.ERDTest do
 
     result = Dot.render(graph, [])
 
-    # Verify that the primary key field has [PK] suffix
-    assert result =~ ~r/:id \[PK\]/
-    # Verify that non-primary fields do not have [PK] suffix
-    refute result =~ ~r/:email \[PK\]/
-    refute result =~ ~r/:name \[PK\]/
+    # Verify that the primary key field is bold
+    assert result =~ ~r/<b>:id\s*<\/b>/
+    # Verify that non-primary fields are not bold
+    refute result =~ ~r/<b>:email\s*<\/b>/
+    refute result =~ ~r/<b>:name\s*<\/b>/
   end
 end

--- a/test/ecto/erd_test.exs
+++ b/test/ecto/erd_test.exs
@@ -11,9 +11,7 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :flow,
-              type:
-                {:parameterized,
-                 {Ecto.Enum, %{on_dump: %{simple: "simple", complex: "complex"}}}}
+              type: {:parameterized, {Ecto.Enum, Ecto.Enum.init(values: [:simple, :complex])}}
             })
           ]
         },
@@ -22,9 +20,7 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :flow,
-              type:
-                {:parameterized,
-                 {Ecto.Enum, %{on_dump: %{simple: "simple", complex: "complex"}}}}
+              type: {:parameterized, {Ecto.Enum, Ecto.Enum.init(values: [:simple, :complex])}}
             })
           ]
         },
@@ -35,8 +31,7 @@ defmodule Ecto.ERDTest do
               name: :status,
               type:
                 {:parameterized,
-                 {Ecto.Enum,
-                  %{on_dump: %{active: "active", suspended: "suspended", invited: "invited"}}}}
+                 {Ecto.Enum, Ecto.Enum.init(values: [:active, :suspended, :invited])}}
             })
           ]
         },
@@ -45,9 +40,7 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :status,
-              type:
-                {:parameterized,
-                 {Ecto.Enum, %{on_dump: %{active: "active", suspended: "suspended"}}}}
+              type: {:parameterized, {Ecto.Enum, Ecto.Enum.init(values: [:active, :suspended])}}
             })
           ]
         },
@@ -56,8 +49,7 @@ defmodule Ecto.ERDTest do
           fields: [
             Field.new(%{
               name: :status,
-              type:
-                {:parameterized, {Ecto.Enum, %{on_dump: %{live: "live", closed: "closed"}}}}
+              type: {:parameterized, {Ecto.Enum, Ecto.Enum.init(values: [:live, :closed])}}
             })
           ]
         }


### PR DESCRIPTION
Previously, the DOT format renderer did not visually distinguish primary key fields from regular fields in generated ERD diagrams. This made it difficult to identify which fields serve as primary keys when viewing the output.

Modified the DOT format renderer in Ecto.ERD.Document.Dot to render primary key fields in **bold** formatting, providing a clean visual distinction without text clutter. This approach offers better visual hierarchy compared to suffix labels.

Primary key fields are now wrapped in HTML `<b>` tags within the DOT table structure, making them stand out prominently in the generated diagrams while maintaining clean, readable output.

Added comprehensive test coverage to verify that:
- Primary key fields are rendered with bold HTML formatting
- Non-primary key fields remain in normal formatting
- The bold formatting works correctly across different field names and types

This enhancement improves the readability of ERD diagrams generated in DOT format, making it easier to quickly identify primary keys in database schema visualizations.