### PR TITLE
Add :enum_values_order and :enum_values_limit options

### DIFF
--- a/lib/ecto/erd/document/dbml.ex
+++ b/lib/ecto/erd/document/dbml.ex
@@ -1,6 +1,6 @@
 defmodule Ecto.ERD.Document.DBML do
   @moduledoc false
-  alias Ecto.ERD.{Node, Field, Edge, Graph, Render}
+  alias Ecto.ERD.{Node, Field, Edge, Graph, Render, EnumValues}
 
   @behaviour Ecto.ERD.Document
 
@@ -8,7 +8,7 @@ defmodule Ecto.ERD.Document.DBML do
   def schemaless?, do: true
 
   @impl true
-  def render(%Graph{nodes: nodes, edges: edges}, _options) do
+  def render(%Graph{nodes: nodes, edges: edges}, opts) do
     groups =
       nodes
       |> Enum.group_by(& &1.cluster, & &1.source)
@@ -21,7 +21,7 @@ defmodule Ecto.ERD.Document.DBML do
         """
       end)
 
-    enums_mapping = enums_mapping(nodes)
+    enums_mapping = enums_mapping(nodes, opts)
 
     enums =
       enums_mapping
@@ -83,13 +83,16 @@ defmodule Ecto.ERD.Document.DBML do
 
   # tries to cut name from #source_#field format to just #field
   @doc false
-  def enums_mapping(nodes) do
+  def enums_mapping(nodes, opts \\ []) do
+    opts = Keyword.put_new(opts, :enum_values_order, :asc)
+
     nodes
     |> Enum.flat_map(fn %Node{source: source, fields: fields} ->
       fields
       |> Enum.flat_map(fn
         %Field{name: name, type: {:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}} ->
-          values = on_dump |> Map.values() |> Enum.sort()
+          {values, truncated?} = EnumValues.prepare(Map.values(on_dump), opts)
+          values = if truncated?, do: values ++ ["..."], else: values
           [{source, name, values}]
 
         _ ->

--- a/lib/ecto/erd/document/dot.ex
+++ b/lib/ecto/erd/document/dot.ex
@@ -1,6 +1,6 @@
 defmodule Ecto.ERD.Document.Dot do
   @moduledoc false
-  alias Ecto.ERD.{HTML, Edge, Node, Field, Graph, Render}
+  alias Ecto.ERD.{HTML, Edge, Node, Field, Graph, Render, EnumValues}
   @behaviour Ecto.ERD.Document
 
   @impl true
@@ -23,7 +23,7 @@ defmodule Ecto.ERD.Document.Dot do
             fontname=#{Render.in_quotes(fontname)}
             color = #{Render.in_quotes(Ecto.ERD.Color.get(cluster_name))}
             label = <#{{:font, ["point-size": 24], {:b, [], cluster_name}} |> HTML.to_iodata()}>
-            #{Enum.map_join(nodes, "\n  ", &render_node(&1, columns))}
+            #{Enum.map_join(nodes, "\n  ", &render_node(&1, columns, opts))}
           }
         """
       end)
@@ -34,7 +34,7 @@ defmodule Ecto.ERD.Document.Dot do
     #{if strict?, do: "strict "}digraph {
       ranksep=1.0; rankdir=LR;
       node [shape = none, fontname=#{Render.in_quotes(fontname)}];
-      #{Enum.map_join(global_nodes, "\n  ", &render_node(&1, columns))}
+      #{Enum.map_join(global_nodes, "\n  ", &render_node(&1, columns, opts))}
     #{subgraphs}
       #{Enum.map_join(edges, "\n  ", &render_edge(&1, columns == []))}
     }
@@ -70,7 +70,8 @@ defmodule Ecto.ERD.Document.Dot do
            source: source,
            schema_module: schema_module
          },
-         columns
+         columns,
+         opts
        ) do
     field_rows =
       if columns == [] or fields == [] do
@@ -82,7 +83,7 @@ defmodule Ecto.ERD.Document.Dot do
             fn column ->
               max_length =
                 fields
-                |> Enum.map(fn field -> field |> format_field(column) |> String.length() end)
+                |> Enum.map(fn field -> field |> format_field(column, opts) |> String.length() end)
                 |> Enum.max()
 
               {column, max_length + 5}
@@ -94,7 +95,7 @@ defmodule Ecto.ERD.Document.Dot do
            {:td, [align: :left, port: Edge.port_name({:field, name})],
             Enum.map(columns, fn
               column ->
-                text = String.pad_trailing(format_field(field, column), column_width[column])
+                text = String.pad_trailing(format_field(field, column, opts), column_width[column])
 
                 case column do
                   :type -> {:i, [], {:font, [color: :gray54], text}}
@@ -139,24 +140,33 @@ defmodule Ecto.ERD.Document.Dot do
     Render.in_quotes(Node.id(source, schema_module)) <> " [label= <#{table}>]"
   end
 
-  defp format_field(%Field{name: name}, :name), do: inspect(name)
+  defp format_field(%Field{name: name}, :name, _opts), do: inspect(name)
 
-  defp format_field(%Field{type: type}, :type), do: format_type(type)
+  defp format_field(%Field{type: type}, :type, opts), do: format_type(type, opts)
 
-  defp format_type({:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}) do
-    "#Enum<#{inspect(Enum.sort(Map.keys(on_dump)), limit: 10)}>"
+  defp format_type({:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}, opts) do
+    opts =
+      opts
+      |> Keyword.put_new(:enum_values_order, :asc)
+      |> Keyword.put_new(:enum_values_limit, 10)
+
+    {values, truncated?} = EnumValues.prepare(Map.keys(on_dump), opts)
+    rendered = values |> Enum.map(&inspect/1) |> Enum.join(", ")
+    suffix = if truncated?, do: ", ...", else: ""
+    "#Enum<[#{rendered}#{suffix}]>"
   end
 
   defp format_type(
          {:parameterized,
-          {Ecto.Embedded, %Ecto.Embedded{cardinality: cardinality, related: related}}}
+          {Ecto.Embedded, %Ecto.Embedded{cardinality: cardinality, related: related}}},
+         _opts
        ) do
     "#Ecto.Embedded<#{inspect([{cardinality, related}])}>"
   end
 
-  defp format_type({:array, type}) do
-    "{:array, #{format_type(type)}}"
+  defp format_type({:array, type}, opts) do
+    "{:array, #{format_type(type, opts)}}"
   end
 
-  defp format_type(type), do: inspect(type)
+  defp format_type(type, _opts), do: inspect(type)
 end

--- a/lib/ecto/erd/document/plantuml.ex
+++ b/lib/ecto/erd/document/plantuml.ex
@@ -1,6 +1,6 @@
 defmodule Ecto.ERD.Document.PlantUML do
   @moduledoc false
-  alias Ecto.ERD.{Node, Edge, Graph, Render, Color}
+  alias Ecto.ERD.{Node, Edge, Graph, Render, Color, EnumValues}
 
   @behaviour Ecto.ERD.Document
   @safe_name_pattern ~r/^[a-z\d_\.:\?]+$/i
@@ -22,12 +22,12 @@ defmodule Ecto.ERD.Document.PlantUML do
       Enum.map(clusters, fn {cluster_name, nodes} ->
         """
         namespace #{cluster_name} #{Color.get(cluster_name)} {
-        #{Enum.map_join(nodes, "\n", &render_node(&1, columns, "  "))}
+        #{Enum.map_join(nodes, "\n", &render_node(&1, columns, "  ", opts))}
         }
         """
       end)
 
-    entities = Enum.map_join(global_nodes, "\n", &render_node(&1, columns, ""))
+    entities = Enum.map_join(global_nodes, "\n", &render_node(&1, columns, "", opts))
 
     refs =
       edges
@@ -67,7 +67,8 @@ defmodule Ecto.ERD.Document.PlantUML do
            schema_module: schema_module
          },
          columns,
-         padding
+         padding,
+         opts
        ) do
     case columns do
       [] ->
@@ -91,7 +92,7 @@ defmodule Ecto.ERD.Document.PlantUML do
                 " : ",
                 fn
                   :name -> Render.in_quotes(field.name, @safe_name_pattern)
-                  :type -> format_type(field.type)
+                  :type -> format_type(field.type, opts)
                 end
               )
           end)
@@ -124,24 +125,14 @@ defmodule Ecto.ERD.Document.PlantUML do
     |> Enum.join(" ")
   end
 
-  defp format_type({:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}) do
-    elements_limit = 10
-    values = Map.values(on_dump)
-    length = length(values)
-
-    values =
-      if length <= elements_limit do
-        values
-      else
-        values
-        |> Enum.slice(0, elements_limit)
-        |> List.replace_at(-1, "...")
-      end
-
+  defp format_type({:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}, opts) do
+    opts = Keyword.put_new(opts, :enum_values_limit, 10)
+    {values, truncated?} = EnumValues.prepare(Map.values(on_dump), opts)
+    values = if truncated?, do: values ++ ["..."], else: values
     "enum(#{Enum.join(values, ",")})"
   end
 
-  defp format_type(type) do
+  defp format_type(type, _opts) do
     case Ecto.Type.type(type) do
       {parent, _t} -> Atom.to_string(parent)
       atom when is_atom(atom) -> Atom.to_string(atom)

--- a/lib/ecto/erd/document/quick_dbd.ex
+++ b/lib/ecto/erd/document/quick_dbd.ex
@@ -1,34 +1,34 @@
 defmodule Ecto.ERD.Document.QuickDBD do
   @moduledoc false
-  alias Ecto.ERD.{Node, Field, Edge, Graph, Render}
+  alias Ecto.ERD.{Node, Field, Edge, Graph, Render, EnumValues}
   @behaviour Ecto.ERD.Document
 
   @impl true
   def schemaless?, do: true
 
   @impl true
-  def render(%Graph{nodes: nodes, edges: edges}, _opts) do
+  def render(%Graph{nodes: nodes, edges: edges}, opts) do
     foreign_keys_mapping =
       Map.new(edges, fn %Edge{to: {to_source, _to_schema, {:field, to_field}}} = edge ->
         {{to_source, to_field}, edge}
       end)
 
-    Enum.map_join(nodes, "\n\n", &render_node(&1, foreign_keys_mapping))
+    Enum.map_join(nodes, "\n\n", &render_node(&1, foreign_keys_mapping, opts))
   end
 
-  defp render_node(%Node{source: source, fields: fields}, foreign_keys_mapping) do
+  defp render_node(%Node{source: source, fields: fields}, foreign_keys_mapping, opts) do
     get_fkey_edge = fn field_name -> foreign_keys_mapping[{source, field_name}] end
 
     [
       source,
       "\n---\n",
       fields
-      |> Enum.map(&render_field(&1, get_fkey_edge))
+      |> Enum.map(&render_field(&1, get_fkey_edge, opts))
       |> Enum.intersperse("\n")
     ]
   end
 
-  defp render_field(%Field{name: name, type: type, primary?: primary?}, get_fkey_edge) do
+  defp render_field(%Field{name: name, type: type, primary?: primary?}, get_fkey_edge, opts) do
     settings =
       if primary? do
         ["PK"]
@@ -55,16 +55,18 @@ defmodule Ecto.ERD.Document.QuickDBD do
       end
 
     Enum.intersperse(
-      [Render.in_quotes(name), Render.in_quotes(format_type(type)) | settings],
+      [Render.in_quotes(name), Render.in_quotes(format_type(type, opts)) | settings],
       " "
     )
   end
 
-  defp format_type({:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}) do
-    "enum(#{Enum.join(Map.values(on_dump), ",")})"
+  defp format_type({:parameterized, {Ecto.Enum, %{on_dump: on_dump}}}, opts) do
+    {values, truncated?} = EnumValues.prepare(Map.values(on_dump), opts)
+    values = if truncated?, do: values ++ ["..."], else: values
+    "enum(#{Enum.join(values, ",")})"
   end
 
-  defp format_type(type) do
+  defp format_type(type, _opts) do
     case Ecto.Type.type(type) do
       {:array, _t} -> "array"
       :id -> "integer"

--- a/lib/ecto/erd/enum_values.ex
+++ b/lib/ecto/erd/enum_values.ex
@@ -1,0 +1,25 @@
+defmodule Ecto.ERD.EnumValues do
+  @moduledoc false
+
+  def prepare(values, opts) do
+    order = Keyword.get(opts, :enum_values_order)
+    limit = Keyword.get(opts, :enum_values_limit, :infinity)
+
+    ordered =
+      case order do
+        nil -> values
+        :asc -> Enum.sort(values)
+        :desc -> Enum.sort(values, :desc)
+      end
+
+    case limit do
+      :infinity -> {ordered, false}
+      n when is_integer(n) and n >= 0 ->
+        if length(ordered) <= n do
+          {ordered, false}
+        else
+          {Enum.take(ordered, n), true}
+        end
+    end
+  end
+end

--- a/lib/mix/tasks/ecto.gen.erd.ex
+++ b/lib/mix/tasks/ecto.gen.erd.ex
@@ -104,6 +104,13 @@ defmodule Mix.Tasks.Ecto.Gen.Erd do
     Return `nil` to remove a node from the diagram.
   * `:otp_app` - the application to scan (along with its dependencies) to collect Ecto schemas.
     Defaults to `Mix.Project.config()[:app]`. Configure this only when running the task from an umbrella root.
+  * `:enum_values_limit` - maximum number of values to display for `Ecto.Enum` fields. Set to a non-negative
+    integer or `:infinity` to display all values. When omitted, each format keeps its historical default:
+    `dot` and `puml` truncate at `10`, `dbml` and `qdbd` list all values (`:infinity`). When the actual list
+    is larger than the limit, the rendered output is suffixed with `...` to indicate truncation.
+  * `:enum_values_order` - sort order applied to `Ecto.Enum` values. Either `:asc` or `:desc`. When omitted,
+    each format keeps its historical default: `dot` and `dbml` sort ascending, `puml` and `qdbd` preserve the
+    original order from the schema definition.
 
   A configuration file with default values for `dot` and `puml` can look like this:
 
@@ -151,7 +158,7 @@ defmodule Mix.Tasks.Ecto.Gen.Erd do
       |> Ecto.ERD.Document.render(
         Path.extname(output_path),
         map_node_callback,
-        Keyword.take(file_opts, [:fontname, :columns])
+        Keyword.take(file_opts, [:fontname, :columns, :enum_values_limit, :enum_values_order])
       )
 
     File.write!(output_path, output)

--- a/test/ecto/erd_test.exs
+++ b/test/ecto/erd_test.exs
@@ -1,7 +1,23 @@
 defmodule Ecto.ERDTest do
   use ExUnit.Case
   alias Ecto.ERD.{Node, Field, Graph}
-  alias Ecto.ERD.Document.{DBML, Dot}
+  alias Ecto.ERD.Document.{DBML, Dot, PlantUML, QuickDBD}
+
+  defp enum_field(values) do
+    Field.new(%{
+      name: :status,
+      type: {:parameterized, {Ecto.Enum, Ecto.Enum.init(values: values)}}
+    })
+  end
+
+  defp enum_graph(values) do
+    %Graph{
+      nodes: [
+        %Node{source: "users", schema_module: MyApp.User, fields: [enum_field(values)]}
+      ],
+      edges: []
+    }
+  end
 
   test inspect(&DBML.enums_mapping/1) do
     result =
@@ -88,5 +104,110 @@ defmodule Ecto.ERDTest do
     # Verify that non-primary fields are not bold
     refute result =~ ~r/<b>:email\s*<\/b>/
     refute result =~ ~r/<b>:name\s*<\/b>/
+  end
+
+  describe "enum_values_order option" do
+    test "DOT defaults to :asc" do
+      assert Dot.render(enum_graph([:b, :a, :c]), []) =~ "#Enum&lt;[:a, :b, :c]&gt;"
+    end
+
+    test "DOT respects :desc" do
+      assert Dot.render(enum_graph([:b, :a, :c]), enum_values_order: :desc) =~
+               "#Enum&lt;[:c, :b, :a]&gt;"
+    end
+
+    test "PlantUML preserves on_dump order by default" do
+      values = [:b, :a, :c]
+      %{on_dump: on_dump} = Ecto.Enum.init(values: values)
+      expected = "enum(#{Enum.join(Map.values(on_dump), ",")})"
+      assert PlantUML.render(enum_graph(values), []) =~ expected
+    end
+
+    test "PlantUML respects :asc" do
+      assert PlantUML.render(enum_graph([:b, :a, :c]), enum_values_order: :asc) =~ "enum(a,b,c)"
+    end
+
+    test "PlantUML respects :desc" do
+      assert PlantUML.render(enum_graph([:b, :a, :c]), enum_values_order: :desc) =~ "enum(c,b,a)"
+    end
+
+    test "QuickDBD preserves on_dump order by default" do
+      values = [:b, :a, :c]
+      %{on_dump: on_dump} = Ecto.Enum.init(values: values)
+      expected = "enum(#{Enum.join(Map.values(on_dump), ",")})"
+      assert QuickDBD.render(enum_graph(values), []) =~ expected
+    end
+
+    test "QuickDBD respects :asc" do
+      assert QuickDBD.render(enum_graph([:b, :a, :c]), enum_values_order: :asc) =~ "enum(a,b,c)"
+    end
+  end
+
+  describe "enum_values_limit option" do
+    @values_11 Enum.map(1..11, &:"v#{&1}")
+
+    test "DOT truncates at 10 by default with `...` suffix" do
+      result = Dot.render(enum_graph(@values_11), [])
+      assert result =~ "..."
+      refute result =~ ":v9,"
+    end
+
+    test "DOT lists everything with :infinity" do
+      result = Dot.render(enum_graph(@values_11), enum_values_limit: :infinity)
+      refute result =~ "..."
+      assert result =~ ":v11"
+      assert result =~ ":v9"
+    end
+
+    test "DOT honors a custom integer limit" do
+      result = Dot.render(enum_graph([:a, :b, :c, :d]), enum_values_limit: 2)
+      assert result =~ "#Enum&lt;[:a, :b, ...]&gt;"
+    end
+
+    test "DOT does not append `...` when limit equals length" do
+      result = Dot.render(enum_graph([:a, :b, :c]), enum_values_limit: 3)
+      refute result =~ "..."
+      assert result =~ "#Enum&lt;[:a, :b, :c]&gt;"
+    end
+
+    test "PlantUML truncates at 10 by default" do
+      assert PlantUML.render(enum_graph(@values_11), []) =~
+               "enum(v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,...)"
+    end
+
+    test "PlantUML lists everything with :infinity" do
+      assert PlantUML.render(enum_graph(@values_11), enum_values_limit: :infinity) =~
+               "enum(v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11)"
+    end
+
+    test "PlantUML honors a custom integer limit" do
+      result = PlantUML.render(enum_graph([:a, :b, :c, :d]), enum_values_limit: 2)
+      assert result =~ ~r/enum\(\w+,\w+,\.\.\.\)/
+    end
+
+    test "QuickDBD lists everything by default" do
+      assert QuickDBD.render(enum_graph(@values_11), []) =~
+               "enum(v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11)"
+    end
+
+    test "QuickDBD honors a custom integer limit" do
+      result = QuickDBD.render(enum_graph([:a, :b, :c, :d]), enum_values_limit: 2)
+      assert result =~ ~r/enum\(\w+,\w+,\.\.\.\)/
+    end
+
+    test "DBML lists everything by default" do
+      result = DBML.render(enum_graph(@values_11), [])
+
+      Enum.each(@values_11, fn value ->
+        assert result =~ to_string(value)
+      end)
+
+      refute result =~ "..."
+    end
+
+    test "DBML honors a custom integer limit and appends `...`" do
+      result = DBML.render(enum_graph([:a, :b, :c, :d]), enum_values_limit: 2)
+      assert result =~ "..."
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds two new options to control how `Ecto.Enum` values are rendered, configurable via `.ecto_erd.exs`:
  - `:enum_values_order` — `:asc` or `:desc`. When omitted, each format keeps its historical default (DOT and DBML sort ascending; PlantUML and QuickDBD preserve the `on_dump` order).
  - `:enum_values_limit` — non-negative integer or `:infinity`. When omitted, each format keeps its historical default (DOT and PlantUML truncate at 10; DBML and QuickDBD list all values).
- Extracts a small helper `Ecto.ERD.EnumValues` so the four formats share the same ordering/limiting logic.
- Replaces `inspect(values, limit: 10)` in the DOT formatter with explicit rendering, so truncation produces a deterministic `, ...` suffix instead of relying on `Inspect`'s built-in truncation.
- All existing defaults are preserved — output for users who don't set the new options is unchanged.

## Motivation

The order returned by `Map.values/1` over `Ecto.Enum`'s internal map isn't deterministic, so when generating the PlantUML output the enum values would sometimes come out in a different order, producing noisy diffs in the generated ERD. On top of that, the hardcoded `limit: 10` in DOT and PlantUML truncated long enums with no way to display them in full.

## Example

```elixir
# .ecto_erd.exs
[
  enum_values_limit: :infinity,
  enum_values_order: :asc
]
```
